### PR TITLE
Feat: Allow javascript files to be translation files

### DIFF
--- a/packages/nuxt3/src/utils.ts
+++ b/packages/nuxt3/src/utils.ts
@@ -29,7 +29,7 @@ export function setupAliasTranspileOptions(
 }
 
 export async function resolveLocales(path: string): Promise<LocaleInfo[]> {
-  const files = await resolveFiles(path, '**/*{json,json5,yaml,yml}')
+  const files = await resolveFiles(path, '**/*{json,json5,yaml,yml,js,ts}')
   return files.map(file => {
     const parsed = parse(file)
     return {


### PR DESCRIPTION
Currently `.js` and `.ts` files are not used for containing translations.

It seems adding these file extensions makes things to work as expected.